### PR TITLE
Add suport for STM32F1 clone CS/CKS32F1

### DIFF
--- a/tcl/target/stm32f1x.cfg
+++ b/tcl/target/stm32f1x.cfg
@@ -40,10 +40,12 @@ if { [info exists CPUTAPID] } {
    } {
       # this is the SW-DP tap id not the jtag tap id
       set _CPUTAPID 0x1ba01477
+      # this is the SW-DP tap id for CKS32F1/CS32F1 "chinise clone" of STM32F1
+      set _CPUTAPIDCLONE 0x2ba01477
    }
 }
 
-swj_newdap $_CHIPNAME cpu -irlen 4 -ircapture 0x1 -irmask 0xf -expected-id $_CPUTAPID
+swj_newdap $_CHIPNAME cpu -irlen 4 -ircapture 0x1 -irmask 0xf -expected-id $_CPUTAPID -expected-id $_CPUTAPIDCLONE
 dap create $_CHIPNAME.dap -chain-position $_CHIPNAME.cpu
 
 if {[using_jtag]} {


### PR DESCRIPTION
This is a little fix for some BluePill that have 0x2ba01477 instead of 0x1ba01477